### PR TITLE
(1-5) 登録者確認画面にてパスワード確認処理を追加しました

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -79,11 +79,16 @@ public class AdministratorController {
 		if (result.hasErrors()) {
 			return "administrator/insert";
 		}
+		if (!(administratorService.isMatchPassword(form.getPassword(), form.getCheckPassword()))) {
+			model.addAttribute("message", "パスワードと確認用パスワードが一致していません");
+			return "administrator/insert";
+		}
 		Administrator administrator = administratorService.searchByMailAddress(form.getMailAddress());
 		if (administrator != null) {
 			model.addAttribute("message", "入力されたメールアドレスは既に登録されています");
 			return "administrator/insert";
 		}
+		administrator = new Administrator();
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -79,7 +79,7 @@ public class AdministratorController {
 		if (result.hasErrors()) {
 			return "administrator/insert";
 		}
-		if (!(administratorService.isMatchPassword(form.getPassword(), form.getCheckPassword()))) {
+		if (!(form.getPassword().equals(form.getCheckPassword()))) {
 			model.addAttribute("message", "パスワードと確認用パスワードが一致していません");
 			return "administrator/insert";
 		}

--- a/src/main/java/com/example/form/InsertAdministratorForm.java
+++ b/src/main/java/com/example/form/InsertAdministratorForm.java
@@ -22,6 +22,18 @@ public class InsertAdministratorForm {
 	@NotBlank(message = "パスワードの入力は必須です")
 	@Size(min = 8, message = "パスワードは8文字以上で入力してください")
 	private String password;
+	/**　確認用パスワード */
+	@NotBlank(message = "確認用パスワードの入力は必須です")
+	@Size(min = 8, message = "確認用パスワードは8文字以上で入力してください")
+	private String checkPassword;
+
+	public String getCheckPassword() {
+		return checkPassword;
+	}
+
+	public void setCheckPassword(String checkPassword) {
+		this.checkPassword = checkPassword;
+	}
 
 	public String getName() {
 		return name;
@@ -50,7 +62,7 @@ public class InsertAdministratorForm {
 	@Override
 	public String toString() {
 		return "InsertAdministratorForm [name=" + name + ", mailAddress=" + mailAddress + ", password=" + password
-				+ "]";
+				+ ", checkPassword=" + checkPassword + "]";
 	}
 
 }

--- a/src/main/java/com/example/service/AdministratorService.java
+++ b/src/main/java/com/example/service/AdministratorService.java
@@ -51,19 +51,4 @@ public class AdministratorService {
 		Administrator administrator = administratorRepository.findByMailAddress(mailAddress);
 		return administrator;
 	}
-
-	/**
-	 * パスワードと確認用パスワードが一致しているかどうかを確認します.
-	 * 
-	 * @param password1 パスワード
-	 * @param password2 確認用パスワード
-	 * @return マッチしているかどうか
-	 */
-	public boolean isMatchPassword(String password1, String password2) {
-		if (password1.equals(password2)) {
-			return true;
-		} else {
-			return false;
-		}
-	}
 }

--- a/src/main/java/com/example/service/AdministratorService.java
+++ b/src/main/java/com/example/service/AdministratorService.java
@@ -51,4 +51,19 @@ public class AdministratorService {
 		Administrator administrator = administratorRepository.findByMailAddress(mailAddress);
 		return administrator;
 	}
+
+	/**
+	 * パスワードと確認用パスワードが一致しているかどうかを確認します.
+	 * 
+	 * @param password1 パスワード
+	 * @param password2 確認用パスワード
+	 * @return マッチしているかどうか
+	 */
+	public boolean isMatchPassword(String password1, String password2) {
+		if (password1.equals(password2)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 }

--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -125,6 +125,30 @@
                     </div>
                   </div>
                 </div>
+                <!-- 確認用パスワード -->
+                <div class="form-group">
+                  <div class="row">
+                    <div class="col-sm-12">
+                      <label for="checkPassword"> 確認用パスワード: </label>
+                      <label
+                        th:errors="*{checkPassword}"
+                        class="error-messages"
+                      >
+                        パスワードを入力してください
+                      </label>
+                      <input
+                        type="password"
+                        name="checkPassword"
+                        id="checkPassword"
+                        class="form-control"
+                        placeholder="password"
+                        th:field="*{checkPassword}"
+                        th:errorclass="error-input"
+                        value="xxxxxxxx"
+                      />
+                    </div>
+                  </div>
+                </div>
                 <!-- 登録ボタン -->
                 <div class="form-group">
                   <div class="row">


### PR DESCRIPTION
登録者確認画面にてパスワード確認処理を追加しました。
登録フォームに確認用パスワード欄を追加し、パスワードが一致していなければ登録フォーム上欄にエラーメッセージが表示されるように改修いたしました。
パスワード確認処理については、ビジネスロジックと判断しServiceクラスにメソッドを定義しています。
ご確認よろしくお願いいたします。