### PR TITLE
(6-2) 従業員一覧ページに名前の曖昧検索フォームを追加しました

### DIFF
--- a/src/main/java/com/example/controller/EmployeeController.java
+++ b/src/main/java/com/example/controller/EmployeeController.java
@@ -1,5 +1,6 @@
 package com.example.controller;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,5 +105,30 @@ public class EmployeeController {
 		employee.setDependentsCount(form.getIntDependentsCount());
 		employeeService.update(employee);
 		return "redirect:/employee/showList";
+	}
+
+	/**
+	 * 従業員一覧を名前で検索します.
+	 * 
+	 * @param name 名前
+	 * @param model requestスコープ
+	 * @return 従業員一覧画面へフォワード
+	 */
+	@PostMapping("/find_name")
+	public String findName(String name, Model model) {
+		List<Employee> employeeList = new ArrayList<>();
+		if (name.isEmpty()) {
+			employeeList = employeeService.showList();
+		} else {
+			employeeList = employeeService.findByName(name);
+			if (employeeList.size() == 0) {
+				employeeList = employeeService.showList();
+				model.addAttribute(("message"), "1件もありませんでした");
+			}
+		}
+
+		model.addAttribute("employeeList", employeeList);
+
+		return "employee/list";
 	}
 }

--- a/src/main/java/com/example/controller/EmployeeController.java
+++ b/src/main/java/com/example/controller/EmployeeController.java
@@ -117,7 +117,7 @@ public class EmployeeController {
 	@PostMapping("/find_name")
 	public String findName(String name, Model model) {
 		List<Employee> employeeList = new ArrayList<>();
-		if (name.isEmpty()) {
+		if (name.isEmpty() || name == null) {
 			employeeList = employeeService.showList();
 		} else {
 			employeeList = employeeService.findByName(name);

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -91,7 +91,7 @@ public class EmployeeRepository {
 	 * @return 従業員リスト
 	 */
 	public List<Employee> findByName(String name) {
-		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees WHERE name LIKE :name;";
+		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees WHERE name LIKE :name ORDER BY hire_date DESC, mail_address ASC;";
 		SqlParameterSource param = new MapSqlParameterSource().addValue("name", "%" + name + "%");
 		List<Employee> employeeList = template.query(sql, param, EMPLOYEE_ROW_MAPPER);
 		return employeeList;

--- a/src/main/java/com/example/repository/EmployeeRepository.java
+++ b/src/main/java/com/example/repository/EmployeeRepository.java
@@ -83,4 +83,17 @@ public class EmployeeRepository {
 		String updateSql = "UPDATE employees SET dependents_count=:dependentsCount WHERE id=:id";
 		template.update(updateSql, param);
 	}
+
+	/**
+	 * 引数の名前から従業員一覧を取得します.
+	 * 
+	 * @param name 名前
+	 * @return 従業員リスト
+	 */
+	public List<Employee> findByName(String name) {
+		String sql = "SELECT id,name,image,gender,hire_date,mail_address,zip_code,address,telephone,salary,characteristics,dependents_count FROM employees WHERE name LIKE :name;";
+		SqlParameterSource param = new MapSqlParameterSource().addValue("name", "%" + name + "%");
+		List<Employee> employeeList = template.query(sql, param, EMPLOYEE_ROW_MAPPER);
+		return employeeList;
+	}
 }

--- a/src/main/java/com/example/service/EmployeeService.java
+++ b/src/main/java/com/example/service/EmployeeService.java
@@ -52,4 +52,9 @@ public class EmployeeService {
 	public void update(Employee employee) {
 		employeeRepository.update(employee);
 	}
+
+	public List<Employee> findByName(String name) {
+		List<Employee> employeeList = employeeRepository.findByName(name);
+		return employeeList;
+	}
 }

--- a/src/main/java/com/example/service/EmployeeService.java
+++ b/src/main/java/com/example/service/EmployeeService.java
@@ -53,6 +53,12 @@ public class EmployeeService {
 		employeeRepository.update(employee);
 	}
 
+	/**
+	 * 引数の名前から従業員情報を取得します.
+	 * 
+	 * @param name 名前
+	 * @return 従業員リスト
+	 */
 	public List<Employee> findByName(String name) {
 		List<Employee> employeeList = employeeRepository.findByName(name);
 		return employeeList;

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -92,11 +92,17 @@
       <!-- table -->
       <div class="row">
         <div
-          class="table-responsive col-lg-offset-2 col-lg-8 col-md-offset-2 col-md-8 col-sm-12 col-xs-12"
+        class="table-responsive col-lg-offset-2 col-lg-8 col-md-offset-2 col-md-8 col-sm-12 col-xs-12"
         >
-          <!-- ここから上を編集する必要はありません -->
+        <!-- ここから上を編集する必要はありません -->
 
-          <!-- ここにモックのtable要素を貼り付けます -->
+         <!-- 従業員名で検索 -->
+          <form th:action="@{/employee/find_name}" method="post">
+            従業員名:<input type="text" name="name">
+            <button>検索</button>
+          </form>
+        
+        <!-- ここにモックのtable要素を貼り付けます -->
 
           <table class="table table-striped">
             <thead>

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -97,6 +97,7 @@
         <!-- ここから上を編集する必要はありません -->
 
          <!-- 従業員名で検索 -->
+          <span th:if="${message}" th:text="${message}"></span>
           <form th:action="@{/employee/find_name}" method="post">
             従業員名:<input type="text" name="name">
             <button>検索</button>


### PR DESCRIPTION
従業員一覧ページに名前の曖昧検索フォームを追加しました。
仕様は以下の通りです。

・何も入力せずに検索した場合
→全件検索結果を表示

・指定した文字列が存在した場合
→指定した文字列が含まれる従業員一覧を表示

・指定した文字列が存在しなかった場合
→「1件もありませんでした」とメッセージを表示し、全件検索結果を表示

また、空白スペースなどを入れて検索をかけた場合は、「指定した文字列が存在しなかった場合」のケースとして扱うとの確認を竹森さんと取りました。

ご確認よろしくお願いいたします。