### PR TITLE
(5-4) ログイン認証フィルターを実装しました

### DIFF
--- a/src/main/java/com/example/common/SecurityConfig.java
+++ b/src/main/java/com/example/common/SecurityConfig.java
@@ -21,13 +21,13 @@ public class SecurityConfig {
                 .loginProcessingUrl("/login")
                 .loginPage("/")
                 .defaultSuccessUrl("/employee/showList")
-                .failureUrl("/")
+                .failureUrl("/?result=error")
                 .usernameParameter("mailAddress")
                 .passwordParameter("password")
                 .permitAll()).logout(logout -> logout
                         .logoutSuccessUrl("/"))
                 .authorizeHttpRequests(authz -> authz
-                        .requestMatchers("/", "/toInsert", "/insert", "/employee/list", "/employee/detail", "/css/**",
+                        .requestMatchers("/", "/toInsert", "/insert", "/css/**",
                                 "/img/**", "/js/**")
                         .permitAll()
                         .anyRequest().authenticated());

--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -109,7 +109,10 @@ public class AdministratorController {
 	 * @return ログイン画面
 	 */
 	@GetMapping("/")
-	public String toLogin() {
+	public String toLogin(String result, Model model) {
+		if ("error".equals(result)) {
+			model.addAttribute("message", "メールアドレスかパスワードが正しくありません");
+		}
 		return "administrator/login";
 	}
 

--- a/src/main/resources/templates/administrator/login.html
+++ b/src/main/resources/templates/administrator/login.html
@@ -35,8 +35,7 @@
             <fieldset>
               <legend>ログイン</legend>
               <div class="form-group">
-                <p th:if="${session['SPRING_SECURITY_LAST_EXCEPTION']}" th:text="メールアドレスかパスワードが正しくありません"
-                  class="alert alert-danger"></p>
+                <p th:if="${message}" th:text="${message}" class="alert alert-danger"></p>
               </div>
               <div class="form-group">
                 <label for="mailAddress">メールアドレス:</label>


### PR DESCRIPTION
ログイン認証フィルターを実装しました。

ログインしていない状態で従業員一覧や従業員詳細画面にアクセスすると、ログイン画面へと遷移するよう修正してあります。
また、メールアドレスやパスワードが間違っていた場合にはエラーメッセージがあるよう作成いたしました。
ご確認よろしくお願いいたします。